### PR TITLE
adds support for Boom errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function toCommonLogFormat (request, options) {
       userid = request.id,
       time = '[' + moment().strftime('%d/%b/%Y:%H:%M:%S %z') + ']',
       requestLine = '"' + [method, path, httpProtocol].join(' ') + '"',
-      statusCode = request.response.statusCode,
+      statusCode = request.response.statusCode || request.response.output.statusCode,
       objectSize = '-';
 
   return [clientIp, clientId, userid, time, requestLine, statusCode, objectSize].join(' ');

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment-tokens": "^1.0.0"
   },
   "devDependencies": {
+    "boom": "^3.1.2",
     "hapi": "^6.4.0",
     "lab": "^4.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,16 @@
 var Lab = require('lab'),
     lab = exports.lab = Lab.script(),
     describe = lab.experiment,
+    beforeEach = lab.beforeEach,
     it = lab.test,
     expect = Lab.expect;
 
 var Hapi = require('hapi'),
+    Boom = require('boom'),
     toCommonLogFormat = require('../'),
     server;
+
+function createServer(done) {
 
   server = Hapi.createServer();
 
@@ -18,8 +22,20 @@ var Hapi = require('hapi'),
     }
   });
 
+  server.route({
+    method: 'GET',
+    path: '/error',
+    handler: function (request, reply) {
+      reply(Boom.notFound());
+    }
+  });
+
+  done();
+}
 
 describe('common log format', function () {
+  beforeEach(createServer);
+
   it('comes through as expected', function (done) {
 
     server.ext('onPostHandler', function (request, next) {
@@ -53,9 +69,45 @@ describe('common log format', function () {
       done();
     });
   });
+
+  it('handles Boom errors', function (done) {
+
+    server.ext('onPostHandler', function (request, next) {
+      var clf = toCommonLogFormat(request);
+
+      var components = clf.split('"');
+
+      var now = new Date();
+      var date = now.toDateString().split(' ');
+      // [ 'Tue',
+      //   'Dec',
+      //   '30',
+      //   '2014' ]
+
+      var time = now.toTimeString().split(' ');
+      // [ '11:52:54', 'GMT-0800', '(PST)' ]
+
+
+      // '%d/%b/%Y:%H:%M:%S %z'
+      var expectedDate = date[2] + '/' + date[1] + '/' + date[3] + ':';
+      var expectedTime = time[0] + ' ' + time[1].slice(3);
+
+      expect(components[0]).to.include('[' + expectedDate + expectedTime + ']');
+      expect(components[1]).to.equal('GET /error HTTP/1.1');
+      expect(components[2]).to.equal(' 404 -');
+
+      next();
+    });
+
+    server.inject({url: '/error'}, function () {
+      done();
+    });
+  });
 });
 
 describe('handling options', function () {
+  beforeEach(createServer);
+
   it('looks up IP from the header if desired', function (done) {
     server.ext('onRequest', function (request, next) {
       request.headers['x-forwarded-to'] = '123.45.678';


### PR DESCRIPTION
Using `reply(Boom.whatever())` is common in Hapi, but `request.response` is handled differently for these cases. We need to use `request.response.output.statusCode` instead of `request.response.statusCode` for Boom errors.
